### PR TITLE
Use Gradle Task Configuration Avoidance

### DIFF
--- a/plugin/src/main/kotlin/pl/droidsonroids/gradle/animation/AnimationDisablerPlugin.kt
+++ b/plugin/src/main/kotlin/pl/droidsonroids/gradle/animation/AnimationDisablerPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.BasePlugin
+import org.gradle.api.tasks.TaskProvider
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
@@ -27,19 +28,19 @@ class AnimationDisablerPlugin : Plugin<Project> {
     }
 
     private fun Project.addAnimationTasksWithDependencies() = afterEvaluate {
-        val disableAnimations = createAnimationScaleTask(false)
-        val enableAnimations = createAnimationScaleTask(true)
+        val disableAnimations = registerAnimationScaleTask(false)
+        val enableAnimations = registerAnimationScaleTask(true)
 
-        tasks.withType(DeviceProviderInstrumentTestTask::class.java).forEach { task ->
+        tasks.withType(DeviceProviderInstrumentTestTask::class.java).configureEach { task ->
             task.dependsOn(disableAnimations)
             task.finalizedBy(enableAnimations)
         }
     }
 
-    private fun Project.createAnimationScaleTask(enableAnimations: Boolean): Task {
+    private fun Project.registerAnimationScaleTask(enableAnimations: Boolean): TaskProvider<Task> {
         val taskName = "connected${if (enableAnimations) "En" else "Dis"}ableAnimations"
 
-        return tasks.create(taskName) {
+        return tasks.register(taskName) {
             val scale = if (enableAnimations) 1f else 0f
             AndroidDebugBridge.initIfNeeded(false)
             val android = project.extensions.getByType(BaseExtension::class.java)


### PR DESCRIPTION
After applying the plugin I've noticed it increases execution of gradle configuration phase by waiting for ADB to initialize:
![image](https://user-images.githubusercontent.com/36954793/79331180-17e5c480-7f1b-11ea-99ba-2cead2d99229.png)

I'm proposing a fix that makes task configuration lazy. 

Side note: the issue is not visible with Android Studio opened as it keeps adb connection alive. After closing AS and stoping adb, the reported issue should be reproducible in 100% cases 